### PR TITLE
Fix tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 
 # add your package requirements here
 install_requires =
-    numpy
+    numpy<1.24.0
     vedo>=2023.4.3
     napari
     vispy


### PR DESCRIPTION
Tests are failing because numpy 1.24.x throws an error in vtk, which is not pinned through vedo. This should fix it.