### PR TITLE
added `frame_by_frame` to elllipsoid curvature measurement

### DIFF
--- a/src/napari_stress/_measurements/curvature.py
+++ b/src/napari_stress/_measurements/curvature.py
@@ -12,6 +12,7 @@ from napari.layers import Layer
 from napari import Viewer
 
 from .._utils import coordinate_conversion as conversion
+from .._utils.frame_by_frame import frame_by_frame
 from ..types import (_METADATAKEY_MEAN_CURVATURE,
                      _METADATAKEY_H0_ELLIPSOID,
                      _METADATAKEY_H_E123_ELLIPSOID,
@@ -27,6 +28,7 @@ from ..types import (_METADATAKEY_MEAN_CURVATURE,
 from typing import Tuple
 
 @register_function(menu="Measurement > Measure mean curvature on ellipsoid (n-STRESS)")
+@frame_by_frame
 def curvature_on_ellipsoid(ellipsoid: VectorsData,
                            sample_points: PointsData) -> LayerDataTuple:
     """

--- a/src/napari_stress/_tests/test_measurements.py
+++ b/src/napari_stress/_tests/test_measurements.py
@@ -206,6 +206,17 @@ def test_curvature2(make_napari_viewer):
     assert results_layer.metadata[types._METADATAKEY_S2_VOLUME_INTEGRAL] is not None
     assert results_layer.metadata[types._METADATAKEY_H0_VOLUME_INTEGRAL] is not None
     
+def test_curvature3():
+    """Tests mean curvatures on ellipsoid"""
+    from napari_stress import get_droplet_point_cloud_4d
+    from napari_stress import approximation, measurements
+
+    pointcloud = get_droplet_point_cloud_4d()[0][0]
+
+    ellipsoid = approximation.least_squares_ellipsoid(pointcloud)
+    approximated_pointcloud = approximation.expand_points_on_ellipse(ellipsoid, pointcloud)
+    curvature = measurements.curvature_on_ellipsoid(ellipsoid, approximated_pointcloud)
+
 
 def test_stresses():
     from napari_stress import lebedev_quadrature
@@ -271,4 +282,4 @@ def test_compatibility_decorator():
 
 
 if __name__ == '__main__':
-    test_spatiotemporal_autocorrelation()
+    test_curvature3()


### PR DESCRIPTION
Bugfix. `measurements.curvature_on_ellipsoid` was not annotated with the `frame_by_frame` decorator and threw an error for 4D data. Fixed it and added a test.