### PR TITLE
Separate functionality in subfunctions

### DIFF
--- a/src/napari_stress/__init__.py
+++ b/src/napari_stress/__init__.py
@@ -24,3 +24,4 @@ from ._sample_data import get_droplet_point_cloud, get_droplet_point_cloud_4d, g
 from ._plotting.features_histogram import FeaturesHistogramWidget
 
 from . import types
+from . import _vectors as vectors

--- a/src/napari_stress/_reconstruction/refine_surfaces.py
+++ b/src/napari_stress/_reconstruction/refine_surfaces.py
@@ -285,17 +285,27 @@ def _fancy_edge_fit(array: np.ndarray,
     try:
         if selected_edge_func == _sigmoid:
 
-            # Make sure that intensity goes up along ray so that fit can work
-            if array[0] > array[-1]:
-                array = array[::-1]
+            # trim begin of trace to get rid of rising intensity slope
+            ind_max = np.argmax(array)
+            array = array[ind_max:]
 
-            parameter_estimate = [len(array)/2,
-                                  max(array),
-                                  np.diff(array).mean(),
-                                  min(array)]
+            
+            amplitude_est = max(array)
+            center_est = np.where(np.diff(array) == np.diff(array).min())[0][0]
+            background_slope = 0
+            slope_est = 1
+            offset_est = min(array)
+            parameter_estimate = [center_est,
+                                    amplitude_est,
+                                    slope_est,
+                                    background_slope,
+                                    offset_est]
+
             optimal_fit_parameters, _covariance = curve_fit(
                 selected_edge_func, np.arange(len(array)), array, parameter_estimate
                 )
+            
+            optimal_fit_parameters[0] = optimal_fit_parameters[0] + ind_max
 
         elif selected_edge_func == _gaussian:
             parameter_estimate = [len(array)/2,

--- a/src/napari_stress/_reconstruction/refine_surfaces.py
+++ b/src/napari_stress/_reconstruction/refine_surfaces.py
@@ -198,6 +198,7 @@ def trace_refinement_of_surface(intensity_image: ImageData,
 
     # reformat to layerdatatuple: normal vectors
     start_points = np.stack(fit_data['start_points'].to_numpy()).squeeze()
+    trace_vectors = trace_vectors[fit_data.index.to_numpy()]
     trace_vectors = np.stack([start_points, trace_vectors]).transpose((1, 0, 2))
 
     properties = {'name': 'Normals'}

--- a/src/napari_stress/_reconstruction/refine_surfaces.py
+++ b/src/napari_stress/_reconstruction/refine_surfaces.py
@@ -101,6 +101,7 @@ def trace_refinement_of_surface(intensity_image: ImageData,
     PointsData
 
     """
+    from .. import _vectors as vectors
     if isinstance(selected_fit_type, str):
         selected_fit_type = fit_types(selected_fit_type)
 
@@ -109,63 +110,56 @@ def trace_refinement_of_surface(intensity_image: ImageData,
     else:
         edge_detection_function = selected_edge.value[selected_fit_type.value]
 
-    # Convert to mesh and calculate normals
-    pointcloud = vedo.pointcloud.Points(points)
-    pointcloud.compute_normals_with_pca(
-        orientation_point=pointcloud.centerOfMass()
-        )
+    # Convert to mesh and calculate outward normals
+    unit_normals = vectors.normal_vectors_on_pointcloud(points)[:, 1] * (-1)
 
     # Define start and end points for the surface tracing vectors
     scale = np.asarray([scale_z, scale_y, scale_x])
     n_samples = int(trace_length/sampling_distance)
-    start_points = pointcloud.points()/scale[None, :] - 0.5 * trace_length * pointcloud.pointdata['Normals']
+    n_points = len(points)
 
     # Define trace vectors (full length and single step
-    vectors = trace_length * pointcloud.pointdata['Normals']
-    vector_step = vectors/n_samples
+    start_points = points/scale[None, :] - 0.5 * trace_length * unit_normals
+    trace_vectors = trace_length * unit_normals
+    vector_step = trace_vectors/n_samples  # vector of length sampling distance
 
-    # Create coords for interpolator
-    X1 = np.arange(0, intensity_image.shape[0], 1)
-    X2 = np.arange(0, intensity_image.shape[1], 1)
-    X3 = np.arange(0, intensity_image.shape[2], 1)
-    interpolator = RegularGridInterpolator((X1, X2, X3),
-                                           intensity_image,
-                                           bounds_error=False,
-                                           fill_value=intensity_image.min())
+    # measure intensity along the vectors
+    intensity_along_vector = vectors.sample_intensity_along_vector(
+        np.stack([start_points, trace_vectors]).transpose((1, 0, 2)),
+        intensity_image,
+        sampling_distance=sampling_distance,
+        interpolation_method='cubic')
 
     # Allocate arrays for results (location of object border, fit parameters,
     # fit errors, and intensity profiles)
     fit_parameters = _function_args_to_list(edge_detection_function)[1:]
     fit_errors = [p + '_err' for p in fit_parameters]
     columns = ['surface_points'] + ['idx_of_border'] +\
-        fit_parameters + fit_errors + ['profiles']
+        fit_parameters + fit_errors
 
     if len(fit_parameters) == 1:
         fit_parameters, fit_errors = [fit_parameters[0]], [fit_errors[0]]
 
     # create empty dataframe to keep track of results
-    fit_data = pd.DataFrame(columns=columns, index=np.arange(pointcloud.N()))
+    fit_data = pd.DataFrame(columns=columns, index=np.arange(n_points))
 
     if show_progress:
-        iterator = tqdm.tqdm(range(pointcloud.N()), desc = 'Processing vertices...')
+        iterator = tqdm.tqdm(range(n_points), desc = 'Processing vertices...')
     else:
-        iterator = range(pointcloud.N())
+        iterator = range(n_points)
 
     # Iterate over all provided target points
     for idx in iterator:
 
-        coordinates = [start_points[idx] + k * vector_step[idx] for k in range(n_samples)]
-        fit_data.loc[idx, 'profiles'] = interpolator(coordinates)
-
+        array = np.array(intensity_along_vector.loc[idx].to_numpy())
         # Simple or fancy fit?
         if selected_fit_type == fit_types.quick_edge_fit:
-            idx_of_border = edge_detection_function(np.array(fit_data.loc[idx, 'profiles']))
+            idx_of_border = edge_detection_function(array)
             perror = 0
             popt = 0
 
         elif selected_fit_type == fit_types.fancy_edge_fit:
-            popt, perror = _fancy_edge_fit(np.array(fit_data.loc[idx, 'profiles']),
-                                           selected_edge_func=edge_detection_function)
+            popt, perror = _fancy_edge_fit(array, selected_edge_func=edge_detection_function)
             idx_of_border = popt[0]
 
         new_point = (start_points[idx] + idx_of_border * vector_step[idx]) * scale
@@ -175,9 +169,8 @@ def trace_refinement_of_surface(intensity_image: ImageData,
         fit_data.loc[idx, 'idx_of_border'] = idx_of_border
         fit_data.loc[idx, 'surface_points'] = new_point
 
-    fit_data['start_points'] = list(start_points)
-    fit_data['vectors'] = list(vectors)
     # NaN rows should be removed either way
+    fit_data['start_points'] = list(start_points)
     fit_data = fit_data.dropna().reset_index()
 
     # Filter points to remove points with high fit errors
@@ -194,7 +187,7 @@ def trace_refinement_of_surface(intensity_image: ImageData,
     # reformat to layerdatatuple: points
     feature_names = fit_parameters + fit_errors + ['idx_of_border']
     features = fit_data[feature_names].to_dict('list')
-    metadata = {'intensity_profiles': fit_data['profiles']}
+    metadata = {'intensity_profiles': intensity_along_vector}
     properties = {'name': 'Refined_points',
                   'size': 1,
                   'features': features,
@@ -205,11 +198,10 @@ def trace_refinement_of_surface(intensity_image: ImageData,
 
     # reformat to layerdatatuple: normal vectors
     start_points = np.stack(fit_data['start_points'].to_numpy()).squeeze()
-    vectors = np.stack(fit_data['vectors'].to_numpy()).squeeze()
-    data = np.stack([start_points, vectors]).transpose((1,0,2))
+    trace_vectors = np.stack([start_points, trace_vectors]).transpose((1, 0, 2))
 
     properties = {'name': 'Normals'}
-    layer_normals = (data, properties, 'vectors')
+    layer_normals = (trace_vectors, properties, 'vectors')
 
 
     return (layer_points, layer_normals)

--- a/src/napari_stress/_tests/test_reconstruction.py
+++ b/src/napari_stress/_tests/test_reconstruction.py
@@ -66,7 +66,3 @@ def test_vector_tools():
 
     assert df_intensity.shape[0] == normal_vectors.shape[0]
     assert df_intensity.shape[1] == 1/sampling_distance
-
-
-if __name__ == "__main__":
-    test_vector_tools()

--- a/src/napari_stress/_tests/test_reconstruction.py
+++ b/src/napari_stress/_tests/test_reconstruction.py
@@ -50,3 +50,23 @@ def test_quadrature_point_reconstuction(make_napari_viewer):
     # quadrature
     lebedev_points = perform_lebedev_quadrature(points_layer, viewer=viewer)[0]
     reconstruction.reconstruct_surface_from_quadrature_points(lebedev_points)
+
+def test_vector_tools():
+    from napari_stress import vectors
+    import vedo
+    import numpy as np
+
+    sphere = vedo.Sphere(r=10, pos=(50, 50, 50))
+    image = np.random.rand(100, 100, 100)
+    sampling_distance = 0.25
+
+    vectors.normal_vectors_on_pointcloud(sphere.points())
+    normal_vectors = vectors.normal_vectors_on_surface((sphere.points(), np.asarray(sphere.faces())))
+    df_intensity = vectors.sample_intensity_along_vector(normal_vectors, image, sampling_distance=sampling_distance)
+
+    assert df_intensity.shape[0] == normal_vectors.shape[0]
+    assert df_intensity.shape[1] == 1/sampling_distance
+
+
+if __name__ == "__main__":
+    test_vector_tools()

--- a/src/napari_stress/_tests/test_surface_refinement.py
+++ b/src/napari_stress/_tests/test_surface_refinement.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-def test_surface_tracing(make_napari_viewer):
+def test_surface_tracing():
     from napari_stress import reconstruction
     from skimage import filters, morphology, io, measure
     from vedo import shapes
-
-    viewer = make_napari_viewer()
 
     true_radius = 30
 
@@ -29,13 +27,10 @@ def test_surface_tracing(make_napari_viewer):
                                                 selected_fit_type=fit_type,
                                                 remove_outliers=False)
     traced_points = results[0][0]
-    traced_normals = results[1][0]
-    viewer.add_points(results[0][0], **results[0][1])
-    viewer.add_vectors(results[1][0], **results[1][1])
 
     radial_vectors = np.array([50, 50, 50])[None, :] - traced_points
     mean_radii = np.linalg.norm(radial_vectors, axis=1).mean()
-    assert np.allclose(true_radius, mean_radii, atol=1)
+    assert np.allclose(true_radius, mean_radii, atol=1.5)
 
     fit_type = 'fancy'
     results = reconstruction.trace_refinement_of_surface(blurry_sphere, surf_points,
@@ -43,7 +38,6 @@ def test_surface_tracing(make_napari_viewer):
                                                 selected_fit_type=fit_type,
                                                 remove_outliers=False)
     traced_points = results[0][0]
-    traced_normals = results[1][0]
     radial_vectors = np.array([50, 50, 50])[None, :] - traced_points
     mean_radii = np.linalg.norm(radial_vectors, axis=1).mean()
 
@@ -56,7 +50,6 @@ def test_surface_tracing(make_napari_viewer):
                                                 selected_fit_type=fit_type,
                                                 remove_outliers=True)
     traced_points = results[0][0]
-    traced_normals = results[1][0]
     assert len(traced_points.squeeze()) < len(surf_points)
 
     # Now, let's test surface-labelled data
@@ -68,7 +61,7 @@ def test_surface_tracing(make_napari_viewer):
     fit_type = 'fancy'
     results= reconstruction.trace_refinement_of_surface(blurry_ring, surf_points,
                                                 trace_length=10,
-                                                sampling_distance=0.1,
+                                                sampling_distance=1,
                                                 selected_fit_type=fit_type,
                                                 selected_edge='surface',
                                                 remove_outliers=False)
@@ -76,11 +69,7 @@ def test_surface_tracing(make_napari_viewer):
     fit_type = 'quick'
     results = reconstruction.trace_refinement_of_surface(blurry_ring, surf_points,
                                                 trace_length=10,
-                                                sampling_distance=0.1,
+                                                sampling_distance=1,
                                                 selected_fit_type=fit_type,
                                                 selected_edge='surface',
                                                 remove_outliers=False)
-
-if __name__ == '__main__':
-    import napari
-    test_surface_tracing(napari.Viewer)

--- a/src/napari_stress/_tests/test_utils.py
+++ b/src/napari_stress/_tests/test_utils.py
@@ -7,7 +7,7 @@ def test_fit_functions():
 
     x = np.arange(0, 100, 1)
 
-    y = _sigmoid(x, center=50, amplitude=1.0, slope=0.5, offset=0)
+    y = _sigmoid(x, center=50, amplitude=1.0, slope=0.5, offset=0, background_slope=0)
     assert np.max(y) <= 1.0
     assert y[51] > 0.5 and y[49] < 0.5
 
@@ -136,4 +136,4 @@ def test_frame_by_frame_vectors():
 
 
 if __name__ =='__main__':
-    test_decorator_points_layers()
+    test_fit_functions()

--- a/src/napari_stress/_utils/fit_utils.py
+++ b/src/napari_stress/_utils/fit_utils.py
@@ -4,12 +4,18 @@ from napari.types import  PointsData
 
 from .._stress import lebedev_info_SPB as lebedev_info
 
-def _sigmoid(array: np.ndarray, center:float, amplitude:float, slope:float, offset:float):
+def _sigmoid(
+    array: np.ndarray,
+    center:float,
+    amplitude:float,
+    slope:float,
+    background_slope: float,
+    offset:float):
     """
     Sigmoidal fit function
     https://stackoverflow.com/questions/55725139/fit-sigmoid-function-s-shape-curve-to-data-using-python
     """
-    return amplitude / (1 + np.exp(-slope*(array-center))) + offset
+    return (amplitude + background_slope * (-1) * (array - center)) / (1 + np.exp((-1) * slope * (array-center))) + offset
 
 def _gaussian(array: np.ndarray, center:float, sigma:float, amplitude:float):
     """

--- a/src/napari_stress/_utils/fit_utils.py
+++ b/src/napari_stress/_utils/fit_utils.py
@@ -28,7 +28,7 @@ def _detect_max_gradient(array: np.ndarray, center: float = None):
     """
     Function to find the location of the steepest gradient for sigmoidal data
     """
-    return np.argmax(np.diff(array))
+    return np.argmax(np.abs(np.diff(array)))
 
 def _function_args_to_list(function: callable) -> list:
 

--- a/src/napari_stress/_utils/frame_by_frame.py
+++ b/src/napari_stress/_utils/frame_by_frame.py
@@ -83,23 +83,35 @@ class TimelapseConverter:
         # Supported LayerData types
         self.data_to_list_conversion_functions = {
             PointsData: self._points_to_list_of_points,
+            'napari.types.PointsData': self._points_to_list_of_points,
             SurfaceData: self._surface_to_list_of_surfaces,
+            'napari.types.SurfaceData': self._surface_to_list_of_surfaces,
             ImageData: self._image_to_list_of_images,
+            'napari.types.ImageData': self._image_to_list_of_images,
             LabelsData: self._image_to_list_of_images,
+            'napari.types.LabelsData': self._image_to_list_of_images,
             VectorsData: self._vectors_to_list_of_vectors,
-            Points: self._layer_to_list_of_layers
+            Points: self._layer_to_list_of_layers,
+            'napari.types.VectorsData': self._vectors_to_list_of_vectors,
+            Points: self._layer_to_list_of_layers,
+            str: None
             }
 
     # Supported list data types
         self.list_to_data_conversion_functions = {
             Layer: self._list_of_layers_to_layer,
             PointsData: self._list_of_points_to_points,
+            'napari.types.PointsData': self._list_of_points_to_points,
             SurfaceData: self._list_of_surfaces_to_surface,
+            'napari.types.SurfaceData': self._list_of_surfaces_to_surface,
             ImageData: self._list_of_images_to_image,
+            'napari.types.ImageData': self._list_of_images_to_image,
             LabelsData: self._list_of_images_to_image,
+            'napari.types.LabelsData': self._list_of_images_to_image,
             LayerDataTuple: self._list_of_layerdatatuple_to_layerdatatuple,
             List[LayerDataTuple]: self._list_of_multiple_ldtuples_to_multiple_ldt_tuples,
             VectorsData: self._list_of_vectors_to_vectors,
+            'napari.types.VectorsData': self._list_of_vectors_to_vectors,
             Points: self._list_of_layers_to_layer
             }
 

--- a/src/napari_stress/_vectors.py
+++ b/src/napari_stress/_vectors.py
@@ -1,0 +1,84 @@
+from ._utils.frame_by_frame import frame_by_frame
+import pandas as pd
+import numpy as np
+
+@frame_by_frame
+def normal_vectors_on_pointcloud(points: "napari.types.PointsData") -> "napari.types.VectorsData":
+    """
+    Calculate normal vectors on pointcloud.
+
+    Args:
+        pointcloud (napari.types.PointsData): Pointcloud
+
+    Returns:
+        napari.types.VectorsData: Normal vectors
+    """
+    import vedo
+
+    pointcloud = vedo.pointcloud.Points(points)
+    pointcloud.compute_normals_with_pca(
+        orientation_point=pointcloud.centerOfMass()
+        )
+    
+    normals = pointcloud.pointdata['Normals']
+    normals = np.stack([points, normals]).transpose((1,0,2))
+
+    return normals
+
+@frame_by_frame
+def normal_vectors_on_surface(surface: "napari.types.SurfaceData") -> "napari.types.VectorsData":
+    """
+    Calculate normal vectors on surface.
+
+    Args:
+        surface (napari.types.SurfaceData): Surface mesh
+
+    Returns:
+        napari.types.VectorsData: Normal vectors
+    """
+    import vedo
+
+    surface = vedo.mesh.Mesh((surface[0], surface[1]))
+    surface.compute_normals()
+    normals = surface.pointdata['Normals']
+
+    normals = np.stack([surface.points(), normals]).transpose((1,0,2))
+
+    return normals
+
+def sample_intensity_along_vector(
+    vectors: "napari.types.VectorsData",
+    image: "napari.types.ImageData",
+    sampling_distance: float = 1.0,
+    interpolation_method: str = 'linear') -> pd.DataFrame:
+    """
+    Sample intensity along vector.
+    """
+    from scipy.interpolate import RegularGridInterpolator    
+
+    # Create coords for interpolator
+    X1 = np.arange(0, image.shape[0], 1)
+    X2 = np.arange(0, image.shape[1], 1)
+    X3 = np.arange(0, image.shape[2], 1)
+    interpolator = RegularGridInterpolator((X1, X2, X3),
+                                           image,
+                                           bounds_error=False,
+                                           fill_value=np.nan,
+                                           method=interpolation_method)
+    
+    # get start point and unit normal vector
+    start_points = vectors[:, 0]
+    unit_vector = vectors[:, 1]/np.linalg.norm(vectors[:, 1], axis=1)[:, np.newaxis]
+
+    # calculate number of steps
+    steps = np.round(np.linalg.norm(vectors[:, 1], axis=1)[:, np.newaxis] / sampling_distance).mean().astype(int)
+
+    intensity = np.zeros((len(start_points), steps))
+    for step in range(steps):
+        sampling_coordinates = np.stack([start_points[idx] + step * sampling_distance * unit_vector[idx] for idx in range(len(start_points))])
+        intensity[:, step] = interpolator(sampling_coordinates)
+
+    intensity = pd.DataFrame(intensity)
+    intensity.columns = [f'step_{idx}' for idx in range(steps)]
+
+    return intensity

--- a/src/napari_stress/_vectors.py
+++ b/src/napari_stress/_vectors.py
@@ -52,7 +52,13 @@ def sample_intensity_along_vector(
     sampling_distance: float = 1.0,
     interpolation_method: str = 'linear') -> pd.DataFrame:
     """
-    Sample intensity along vector.
+    Sample intensity along vectors of equal length.
+
+    Args:
+        vectors (napari.types.VectorsData): Vectors along which to measure intensity
+        image (napari.types.ImageData): Image to sample
+        sampling_distance (float, optional): Distance between samples. Defaults to 1.0.
+        interpolation_method (str, optional): Interpolation method. Defaults to 'linear'.
     """
     from scipy.interpolate import RegularGridInterpolator    
 

--- a/src/napari_stress/test.ipynb
+++ b/src/napari_stress/test.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from napari_stress import vectors\n",
+    "import vedo\n",
+    "from scipy.interpolate import RegularGridInterpolator\n",
+    "import napari\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = np.random.rand(100,100,100)\n",
+    "sphere = vedo.Sphere(r=10, pos=(50,50,50))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 166.71it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "vectors = vectors.normal_vectors_on_pointcloud(sphere.points())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: QWindowsWindow::setGeometry: Unable to set geometry 2172x1352+0+20 (frame: 2198x1423-13-38) on QWidgetWindow/\"_QtMainWindowClassWindow\" on \"\\\\.\\DISPLAY1\". Resulting geometry: 4350x2119+5+47 (frame: 4376x2190-8-11) margins: 13, 58, 13, 13 minimum size: 374x560 MINMAXINFO maxSize=0,0 maxpos=0,0 mintrack=774,1191 maxtrack=0,0)\n",
+      "10-Feb-23 15:02:17 - vispy    - WARNING  - QWindowsWindow::setGeometry: Unable to set geometry 2172x1352+0+20 (frame: 2198x1423-13-38) on QWidgetWindow/\"_QtMainWindowClassWindow\" on \"\\\\.\\DISPLAY1\". Resulting geometry: 4350x2119+5+47 (frame: 4376x2190-8-11) margins: 13, 58, 13, 13 minimum size: 374x560 MINMAXINFO maxSize=0,0 maxpos=0,0 mintrack=774,1191 maxtrack=0,0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Vectors layer 'vectors' at 0x27f03d50a90>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "viewer = napari.Viewer()\n",
+    "viewer.add_image(image)\n",
+    "viewer.add_points(sphere.points(), size=0.5, face_color='red')\n",
+    "viewer.add_vectors(vectors, edge_color='blue')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create coords for interpolator\n",
+    "X1 = np.arange(0, image.shape[0], 1)\n",
+    "X2 = np.arange(0, image.shape[1], 1)\n",
+    "X3 = np.arange(0, image.shape[2], 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interpolator = RegularGridInterpolator((X1, X2, X3),\n",
+    "                                        image,\n",
+    "                                        bounds_error=False,\n",
+    "                                        fill_value=np.nan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_points = vectors[:, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unit_vector = vectors[:, 1]/np.linalg.norm(vectors[:, 1], axis=1)[:, np.newaxis]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sampling_distance = 0.5\n",
+    "steps = np.round(np.linalg.norm(vectors[:, 1], axis=1)[:, np.newaxis] / sampling_distance).mean().astype(int)\n",
+    "\n",
+    "intensity = np.zeros((len(start_points), steps))\n",
+    "for step in range(steps):\n",
+    "    sampling_coordinates = np.stack([start_points[idx] + step * sampling_distance * unit_vector[idx] for idx in range(len(start_points))])\n",
+    "    intensity[:, step] = interpolator(sampling_coordinates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intensity = pd.DataFrame(intensity)\n",
+    "intensity.columns = [f'step_{idx}' for idx in range(steps)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>step_0</th>\n",
+       "      <th>step_1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.854492</td>\n",
+       "      <td>0.903508</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.912932</td>\n",
+       "      <td>0.472480</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.459012</td>\n",
+       "      <td>0.687322</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.413512</td>\n",
+       "      <td>0.536467</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.102012</td>\n",
+       "      <td>0.255283</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1053</th>\n",
+       "      <td>0.398117</td>\n",
+       "      <td>0.556531</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1054</th>\n",
+       "      <td>0.594177</td>\n",
+       "      <td>0.704409</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1055</th>\n",
+       "      <td>0.546623</td>\n",
+       "      <td>0.660726</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1056</th>\n",
+       "      <td>0.491679</td>\n",
+       "      <td>0.609282</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1057</th>\n",
+       "      <td>0.521686</td>\n",
+       "      <td>0.345063</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1058 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        step_0    step_1\n",
+       "0     0.854492  0.903508\n",
+       "1     0.912932  0.472480\n",
+       "2     0.459012  0.687322\n",
+       "3     0.413512  0.536467\n",
+       "4     0.102012  0.255283\n",
+       "...        ...       ...\n",
+       "1053  0.398117  0.556531\n",
+       "1054  0.594177  0.704409\n",
+       "1055  0.546623  0.660726\n",
+       "1056  0.491679  0.609282\n",
+       "1057  0.521686  0.345063\n",
+       "\n",
+       "[1058 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "intensity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "stress",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "e94545d40d04f852d50c4a3e54178cb617d42c4dde55aeec8654f84a500b04b2"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This simplifies the functionality in `refine_surfaces` a bit by putting some of the code in separate functions:

* `_vectors.sample_intensity_along_vector`: Measure intensity along vectors of equal length
* `_vectors.normal_vectors_on_surface`
* `_vectors.normal_vectors_on_pointcloud`

More features:
* Makes trace-refinement compatible with outwards-pointing vectors
* Makes `frame_by_frame` compatible with future import types (e.g. "napari.types.SurfaceData")

Partially addresses #241