### PR TITLE
Add autocorrelation to exports

### DIFF
--- a/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
+++ b/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
@@ -1644,9 +1644,41 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "61ac8681",
+   "metadata": {},
+   "source": [
+    "## Export data\n",
+    "\n",
+    "We first agregate the data from the spatial autocorrelations in a separate dataframe. This dataframe has a column for autocorrelations of total, cell and tissue-scale stresses."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61ac8681",
+   "id": "186f12be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_autocorrelations = pd.merge(\n",
+    "    df_autocorrelations_total,\n",
+    "    df_autocorrelations_tissue,\n",
+    "    'left',\n",
+    "    on=['time', 'distances'],)\n",
+    "df_autocorrelations = pd.merge(\n",
+    "    df_autocorrelations,\n",
+    "    df_autocorrelations_cell, \n",
+    "    'left',\n",
+    "    on=['time', 'distances'])\n",
+    "\n",
+    "df_autocorrelations.to_csv(os.path.join(save_directory, 'results_autocorrelations.csv'), index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "127073f0",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
+++ b/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "id": "92cdbcda-ad6d-4048-a1eb-f2a452969326",
    "metadata": {},
    "outputs": [],
@@ -25,6 +25,7 @@
     "import napari_process_points_and_surfaces as nppas\n",
     "import vedo\n",
     "import os\n",
+    "import datetime\n",
     "\n",
     "from skimage import io\n",
     "\n",
@@ -44,26 +45,15 @@
    "source": [
     "## Load the data\n",
     "\n",
-    "Replace the following code with the commented out part below to load your own data for analysis:"
+    "Replace the following code with the commented out part (and remove the rest) below to load your own data for analysis:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "id": "b2d722d6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(21, 16, 30, 31)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "example_data = napari_stress.get_droplet_4d()[0][0]\n",
     "example_data.shape\n",
@@ -85,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 15,
    "id": "84dee937-8ecd-4f19-81c0-8d67e708d727",
    "metadata": {},
    "outputs": [],
@@ -109,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "id": "bc558d67-0cb5-40c9-aa41-8a90548a43ea",
    "metadata": {},
    "outputs": [],
@@ -135,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "id": "8656d43b-d498-4dba-a5da-147987306bce",
    "metadata": {},
    "outputs": [],
@@ -155,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 18,
    "id": "c011ebda-b9f0-4bb9-9db7-46b3947af1cc",
    "metadata": {},
    "outputs": [],
@@ -175,35 +165,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "e440ed15-c9bd-454f-8583-2aaa071142bb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assistant skips harvesting pyclesperanto as it's not installed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "viewer = napari.Viewer(ndisplay=3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "id": "844ff331-de44-44dd-a584-50da9abe8357",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Image layer 'example_data' at 0x1f54e793700>"
+       "<Image layer 'example_data' at 0x22ca0fd6e50>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -214,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 21,
    "id": "db8d0a48-1489-44c3-85f5-e6aa916e3a1b",
    "metadata": {},
    "outputs": [],
@@ -224,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 22,
    "id": "1ca6756f-cc9e-454f-bef9-906ed59c3657",
    "metadata": {},
    "outputs": [
@@ -232,21 +214,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/21 [00:00<?, ?it/s]"
+      "100%|██████████| 21/21 [00:03<00:00,  6.68it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dask client up an running <Client: 'tcp://127.0.0.1:51107' processes=4 threads=16, memory=31.72 GiB>  Log: https://localhost:8787\n"
+      "Dask client up an running <Client: 'tcp://127.0.0.1:55911' processes=4 threads=16, memory=31.72 GiB>  Log: https://localhost:8787\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 21/21 [00:09<00:00,  2.11it/s]\n"
+      "\n"
      ]
     }
    ],
@@ -269,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 23,
    "id": "0dbe3a56-c592-42da-a536-d3237638c4d8",
    "metadata": {},
    "outputs": [],
@@ -294,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 24,
    "id": "561cc659-dc22-4a56-9dca-cd738e7506f5",
    "metadata": {},
    "outputs": [
@@ -302,21 +284,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 21/21 [00:03<00:00,  5.68it/s]"
+      " 19%|█▉        | 4/21 [00:03<00:10,  1.68it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dask client up an running <Client: 'tcp://127.0.0.1:52491' processes=4 threads=16, memory=31.72 GiB>  Log: https://localhost:8787\n"
+      "Dask client up an running <Client: 'tcp://127.0.0.1:56050' processes=4 threads=16, memory=31.72 GiB>  Log: https://localhost:8787\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\n"
+      "100%|██████████| 21/21 [00:03<00:00,  6.46it/s]\n",
+      "2023-03-02 09:12:33,443 - distributed.nanny - WARNING - Worker process still alive after 3.1999978637695317 seconds, killing\n"
      ]
     }
    ],
@@ -345,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 25,
    "id": "be9ccf3c",
    "metadata": {},
    "outputs": [
@@ -424,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 26,
    "id": "f5a6722e",
    "metadata": {},
    "outputs": [],
@@ -445,30 +428,48 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2ff914ec-5481-4091-a462-8c961aa2fee9",
    "metadata": {},
    "source": [
-    "# Visualization"
+    "# Visualization\n",
+    "\n",
+    "In this section, we will plot some interesting results and save the data to disk. The file location will be at the "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 27,
    "id": "ad6257da-d122-43b4-bbe7-e663a950f204",
    "metadata": {},
    "outputs": [],
    "source": [
     "mpl.style.use('default')\n",
-    "save_directory = os.path.pardir()"
+    "colormap = 'seismic'\n",
+    "if filename is not None:\n",
+    "    filename_without_ending = os.path.basename(filename).split('.')[0]\n",
+    "    save_directory = os.path.join(os.path.dirname(filename), filename_without_ending + '_' + datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 28,
    "id": "759f6d4a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'save_directory' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[28], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m os\u001b[39m.\u001b[39mpath\u001b[39m.\u001b[39mexists(save_directory):\n\u001b[0;32m      2\u001b[0m     os\u001b[39m.\u001b[39mmakedirs(save_directory)\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'save_directory' is not defined"
+     ]
+    }
+   ],
    "source": [
     "if not os.path.exists(save_directory):\n",
     "    os.makedirs(save_directory)"
@@ -487,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "3263b9de",
    "metadata": {},
    "outputs": [
@@ -814,7 +815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "55d1cced-6afa-492c-98f8-c239ed04b201",
    "metadata": {},
    "outputs": [
@@ -874,7 +875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "9f1ab341-0f58-44e4-a896-53d80efe763e",
    "metadata": {},
    "outputs": [
@@ -919,7 +920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "39c5f30b-3546-4ce6-aefb-be3a96a3e523",
    "metadata": {},
    "outputs": [
@@ -960,7 +961,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "dc3565b4-dffd-44c8-8f14-0bcd1e702602",
    "metadata": {},
    "outputs": [
@@ -1003,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "bec7696f-a0c1-409a-a8cc-b8a917a3118d",
    "metadata": {},
    "outputs": [],
@@ -1013,7 +1014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "64cf909a-d7fa-47a4-bba8-068f0c94428f",
    "metadata": {},
    "outputs": [],
@@ -1037,7 +1038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "5a8c0d1e-8233-40ff-af8e-db391c25b2ad",
    "metadata": {},
    "outputs": [
@@ -1080,7 +1081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "25682ad2-780b-4ffe-93df-985513a37922",
    "metadata": {},
    "outputs": [],
@@ -1090,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "eef1ea18-70c7-4118-b9c2-8c5187f8c79b",
    "metadata": {},
    "outputs": [],
@@ -1114,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "b4abe045-158e-4133-b171-6dab620dd86a",
    "metadata": {},
    "outputs": [
@@ -1157,7 +1158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "72be4d15-374d-4769-a734-c34931a9e83b",
    "metadata": {},
    "outputs": [],
@@ -1170,7 +1171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "d925a14a-8cca-47e6-a88b-92c3672e2ba3",
    "metadata": {},
    "outputs": [
@@ -1209,7 +1210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "84606517-f802-4ad5-9596-098dc17efa2c",
    "metadata": {},
    "outputs": [],
@@ -1227,7 +1228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "28282dae-910e-419e-8668-8ec0de5da90c",
    "metadata": {},
    "outputs": [],
@@ -1248,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "931b66e0-27e5-4967-91aa-ab78860e11ba",
    "metadata": {},
    "outputs": [
@@ -1286,7 +1287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "f3959e2e-a9c5-496f-ae64-86ab18ba4039",
    "metadata": {},
    "outputs": [],
@@ -1297,7 +1298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "2236a217-1126-4476-baf1-e3ba89b63148",
    "metadata": {},
    "outputs": [],
@@ -1311,7 +1312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "d5dc28d5-d9e4-45ba-bb9b-193e934b2c45",
    "metadata": {},
    "outputs": [],
@@ -1326,7 +1327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "d7d7d1e3-4caa-46a3-b6db-8a13ad8cb36e",
    "metadata": {},
    "outputs": [
@@ -1366,7 +1367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "75db5953-69f0-454e-85db-205e76e3e8cb",
    "metadata": {},
    "outputs": [],
@@ -1377,7 +1378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "a7d2c468-ac1e-4b11-a82f-a4c6c14bf792",
    "metadata": {},
    "outputs": [],
@@ -1394,7 +1395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "45615d6f-3e22-494a-8e9f-551798b0036e",
    "metadata": {},
    "outputs": [],
@@ -1411,7 +1412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "ffcc79ed-e512-43b6-bb7d-0136548052d9",
    "metadata": {},
    "outputs": [],
@@ -1428,7 +1429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "c69bc224-11d5-48ed-8649-96bb4603dd47",
    "metadata": {},
    "outputs": [
@@ -1473,7 +1474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "b0d5f738-ae4e-4cf6-a189-daa8a8278278",
    "metadata": {},
    "outputs": [],
@@ -1484,7 +1485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "c21395e1-1792-48a2-b9bf-54f8e4089883",
    "metadata": {},
    "outputs": [],
@@ -1496,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "111b02cf-fcc0-4650-851d-b2f50db60390",
    "metadata": {},
    "outputs": [
@@ -1536,7 +1537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "a96a0172-224a-4bcd-ac22-a7df33e147a7",
    "metadata": {},
    "outputs": [],
@@ -1547,7 +1548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "d0b1d80d-dfae-41de-b8a6-9306ec7b88cd",
    "metadata": {},
    "outputs": [
@@ -1590,7 +1591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "069df7aa",
    "metadata": {},
    "outputs": [

--- a/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
+++ b/docs/02_toolboxes/03_analyze_everything/demo_analyze_everything.ipynb
@@ -37,27 +37,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5c345d48-d58a-45af-9640-f073b753d367",
-   "metadata": {},
-   "source": [
-    "## Config\n",
-    "\n",
-    "For plotting:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "f85a6d17-558d-4d79-9cda-4e5e75706f65",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "save_directory = 'path/to/save/directory'\n",
-    "colormap = 'seismic'"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "87a6fa3c-9eae-48cd-8eca-52dd0cbaed49",
@@ -88,9 +67,11 @@
    "source": [
     "example_data = napari_stress.get_droplet_4d()[0][0]\n",
     "example_data.shape\n",
+    "filename = None\n",
     "\n",
-    "# Replace this code with a command to import your data. Example:\n",
-    "# example_data = io.imread('path/to/data.tif')"
+    "## Replace this code with a command to import your data. Example:\n",
+    "# filename = 'path/to/data.tif'\n",
+    "# example_data = io.imread(filename)"
    ]
   },
   {
@@ -478,7 +459,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mpl.style.use('default')"
+    "mpl.style.use('default')\n",
+    "save_directory = os.path.pardir()"
    ]
   },
   {


### PR DESCRIPTION
This adds the autocorrelation to the exported data of the `demo_analyzed_everything.ipynb` notebook. It will also automatically create a timestamped folder where the analyzed data should go.