### PR TITLE
Fix bug in geodesic distance

### DIFF
--- a/src/napari_stress/_measurements/toolbox.py
+++ b/src/napari_stress/_measurements/toolbox.py
@@ -293,7 +293,7 @@ def comprehensive_analysis(pointcloud: PointsData,
                                                     show_progress=verbose)
 
     if maximal_distance is None:
-        maximal_distance = int(np.floor(GDM.max()))
+        maximal_distance = int(np.floor(np.nanmax(GDM[GDM != np.inf])))
 
     # Compute Overall total stress spatial correlations
     autocorrelations_total = measurements.correlation_on_surface(


### PR DESCRIPTION
Tis fixes a bug in the calculation of the geodesic distance matrix. The error occurs if geodesic distances cannot be measured properly. This is not an error with the GDM (but rather the delineated pointcloud) but it shouldn't cancel the executed workflow.