### PR TITLE
Add more decimals

### DIFF
--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -42,6 +42,8 @@ class droplet_reconstruction_toolbox(QWidget):
         self.pushButton_run.clicked.connect(self._run)
         self.image_layer_select.changed.connect(self._set_scales)
 
+        self._set_scales()
+
     def eventFilter(self, obj: QObject, event: QEvent):
         """https://forum.image.sc/t/composing-workflows-in-napari/61222/3."""
         if event.type() == QEvent.ParentChange:
@@ -51,11 +53,14 @@ class droplet_reconstruction_toolbox(QWidget):
 
     def _set_scales(self):
         """Get scales from loaded data."""
-        scales = self.image_layer_select.value.scale
-        scales = scales[-3:]  # scales may be 4D
-        self.doubleSpinBox_voxelsize_x.setValue(scales[2])
-        self.doubleSpinBox_voxelsize_y.setValue(scales[1])
-        self.doubleSpinBox_voxelsize_z.setValue(scales[0])
+        try:
+            scales = self.image_layer_select.value.scale
+            scales = scales[-3:]  # scales may be 4D
+            self.doubleSpinBox_voxelsize_x.setValue(scales[2])
+            self.doubleSpinBox_voxelsize_y.setValue(scales[1])
+            self.doubleSpinBox_voxelsize_z.setValue(scales[0])
+        except Exception:
+            pass
 
     def _run(self):
         """Call analysis function."""

--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -40,6 +40,7 @@ class droplet_reconstruction_toolbox(QWidget):
         self.spinBox_n_vertices.setValue(256)
 
         self.pushButton_run.clicked.connect(self._run)
+        self.image_layer_select.changed.connect(self._set_scales)
 
     def eventFilter(self, obj: QObject, event: QEvent):
         """https://forum.image.sc/t/composing-workflows-in-napari/61222/3."""
@@ -47,6 +48,14 @@ class droplet_reconstruction_toolbox(QWidget):
             self.image_layer_select.parent_changed.emit(self.parent())
 
         return super().eventFilter(obj, event)
+
+    def _set_scales(self):
+        """Get scales from loaded data."""
+        scales = self.image_layer_select.value.scale
+        scales = scales[-3:]  # scales may be 4D
+        self.doubleSpinBox_voxelsize_x.setValue(scales[2])
+        self.doubleSpinBox_voxelsize_y.setValue(scales[1])
+        self.doubleSpinBox_voxelsize_z.setValue(scales[0])
 
     def _run(self):
         """Call analysis function."""

--- a/src/napari_stress/_reconstruction/toolbox.ui
+++ b/src/napari_stress/_reconstruction/toolbox.ui
@@ -27,7 +27,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QToolBox" name="toolBox">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="page_3">
       <property name="geometry">
@@ -44,6 +44,9 @@
       <layout class="QGridLayout" name="gridLayout_7">
        <item row="0" column="1">
         <widget class="QDoubleSpinBox" name="doubleSpinBox_voxelsize_x">
+         <property name="decimals">
+          <number>4</number>
+         </property>
          <property name="value">
           <double>1.000000000000000</double>
          </property>
@@ -65,6 +68,9 @@
        </item>
        <item row="3" column="1">
         <widget class="QDoubleSpinBox" name="doubleSpinBox_target_voxelsize">
+         <property name="decimals">
+          <number>4</number>
+         </property>
          <property name="value">
           <double>1.000000000000000</double>
          </property>
@@ -86,6 +92,9 @@
        </item>
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="doubleSpinBox_voxelsize_y">
+         <property name="decimals">
+          <number>4</number>
+         </property>
          <property name="value">
           <double>1.000000000000000</double>
          </property>
@@ -93,6 +102,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QDoubleSpinBox" name="doubleSpinBox_voxelsize_z">
+         <property name="decimals">
+          <number>4</number>
+         </property>
          <property name="value">
           <double>1.000000000000000</double>
          </property>

--- a/src/napari_stress/_reconstruction/toolbox.ui
+++ b/src/napari_stress/_reconstruction/toolbox.ui
@@ -35,7 +35,7 @@
         <x>0</x>
         <y>0</y>
         <width>855</width>
-        <height>308</height>
+        <height>312</height>
        </rect>
       </property>
       <attribute name="label">
@@ -119,7 +119,7 @@
         <x>0</x>
         <y>0</y>
         <width>855</width>
-        <height>308</height>
+        <height>312</height>
        </rect>
       </property>
       <attribute name="label">
@@ -199,9 +199,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-53</y>
+        <y>0</y>
         <width>838</width>
-        <height>365</height>
+        <height>371</height>
        </rect>
       </property>
       <attribute name="label">
@@ -432,6 +432,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>doubleSpinBox_voxelsize_x</tabstop>
+  <tabstop>doubleSpinBox_voxelsize_y</tabstop>
+  <tabstop>doubleSpinBox_voxelsize_z</tabstop>
+  <tabstop>doubleSpinBox_target_voxelsize</tabstop>
+  <tabstop>doubleSpinBox_gaussian_blur</tabstop>
+  <tabstop>spinBox_n_vertices</tabstop>
+  <tabstop>spinBox_n_smoothing</tabstop>
+  <tabstop>spinBox_n_refinement_steps</tabstop>
+  <tabstop>doubleSpinBox_sampling_length</tabstop>
+  <tabstop>comboBox_fittype</tabstop>
+  <tabstop>comboBox_fluorescence_type</tabstop>
+  <tabstop>doubleSpinBox_trace_length</tabstop>
+  <tabstop>doubleSpinBox_sampling_distance</tabstop>
+  <tabstop>comboBox_interpolation_method</tabstop>
+  <tabstop>checkBox_remove_outliers</tabstop>
+  <tabstop>doubleSpinBox_outlier_tolerance</tabstop>
+  <tabstop>pushButton_run</tabstop>
+  <tabstop>checkBox_use_dask</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/napari_stress/_tests/test_reconstruction.py
+++ b/src/napari_stress/_tests/test_reconstruction.py
@@ -9,14 +9,19 @@ def test_reconstruction(make_napari_viewer):
 
     viewer = make_napari_viewer()
     image = get_droplet_4d()[0][0]
-    viewer.add_image(image)
+    viewer.add_image(image, scale=[1.1, 1.1, 1.1], name='image')
 
     widget = napari_stress._reconstruction.toolbox.droplet_reconstruction_toolbox(viewer)
     viewer.window.add_dock_widget(widget)
 
+    assert widget.doubleSpinBox_voxelsize_x.value() == 1.1
+    assert widget.doubleSpinBox_voxelsize_y.value() == 1.1
+    assert widget.doubleSpinBox_voxelsize_z.value() == 1.1
+
     results = reconstruction.reconstruct_droplet(
         image,
         voxelsize=np.asarray([1.93, 1, 1]),
+        interpolation_method='linear',
         target_voxelsize=1
         )
 
@@ -29,6 +34,7 @@ def test_reconstruction(make_napari_viewer):
         image,
         voxelsize=np.asarray([1.93, 1, 1]),
         target_voxelsize=1,
+        interpolation_method='linear',
         resampling_length=1,
         use_dask=True
         )


### PR DESCRIPTION
#294 

This PR

- automatically reads the voxel dimensions from the image data in the viewer. In case libraries like aicsimageio are used, these will be the correct dimension. A
- Adds more decimal places to the voxel sizes to prevent rounding errors for high resolution
- Fixes the tab order of the reconstruction toolbox