### PR TITLE
Revert "replaced pygeodesics by vedo and pyFM"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,13 +37,14 @@ install_requires =
     matplotlib
     mpmath
     napari
-    napari-matplotlib==0.2.0
+    napari-matplotlib
     napari-process-points-and-surfaces>=0.4.0
     napari-segment-blobs-and-things-with-membranes
     napari-tools-menu>=0.1.15
     numpy<1.24.0
     pandas
     pyclesperanto-prototype
+    pygeodesic
     pyocclient
     pyshtools<=4.10.0
     scikit-image
@@ -52,7 +53,6 @@ install_requires =
     tqdm
     vedo>=2023.4.3
     vispy
-    pyFM @ git+https://github.com/jo-mueller/pyFM.git
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     matplotlib
     mpmath
     napari
-    napari-matplotlib
+    napari-matplotlib==0.2.0
     napari-process-points-and-surfaces>=0.4.0
     napari-segment-blobs-and-things-with-membranes
     napari-tools-menu>=0.1.15

--- a/src/napari_stress/_measurements/geodesics.py
+++ b/src/napari_stress/_measurements/geodesics.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+import tqdm
 from napari.types import LayerDataTuple, SurfaceData, VectorsData
 from napari_tools_menu import register_function
 
@@ -8,9 +9,7 @@ from .._utils.frame_by_frame import frame_by_frame
 
 
 def geodesic_distance_matrix(
-    surface: SurfaceData,
-    show_progress: bool = False,
-    method: str = "dijkstra",
+    surface: SurfaceData, show_progress: bool = False
 ) -> np.ndarray:
     """
     Calculate a pairwise distance matrix for vertices of a surface.
@@ -21,66 +20,69 @@ def geodesic_distance_matrix(
     Parameters
     ----------
     surface : SurfaceData
-    show_progress : bool, optional
-        Show progress bar. The default is False.
-    method : str, optional
-        Method to use for geodesic distance calculation. The default is
-        "dijkstra". Other option is "heat". For more information, see
-        [pyFM](https://github.com/RobinMagnet/pyFM/tree/master)
 
     Returns
     -------
-    np.ndarray
-        Pairwise distance matrix.
+    distance_matrix : np.ndarray
+        Triangular matrix with differences between vertex i and j located
+        at `distance_matrix[i, j]`
+
     """
-    from pyFM.mesh import TriMesh
+    from pygeodesic import geodesic
 
-    surface_trimesh = TriMesh(surface[0], surface[1])
+    geoalg = geodesic.PyGeodesicAlgorithmExact(surface[0], surface[1])
 
-    if method == "dijkstra":
-        distance_matrix = surface_trimesh.get_geodesic(
-            verbose=show_progress,
-            dijkstra=True,)
-    elif method == "heat":
-        distance_matrix = surface_trimesh.get_geodesic(
-            verbose=show_progress,
-            robust=True)
+    n_points = len(surface[0])
+    distance_matrix = np.zeros((n_points, n_points))
+    points = surface[0]
+
+    if show_progress:
+        iterator = tqdm.tqdm(enumerate(points), desc='Calculating geodesic distances')
+    else:
+        iterator = enumerate(points)
+
+    for idx, pt in iterator:
+        distances, _ = geoalg.geodesicDistances(
+            [idx], np.arange(idx + 1, n_points))
+        distance_matrix[idx, idx + 1:] = distances
+        distance_matrix[idx + 1:, idx] = distances
 
     return distance_matrix
 
 
-@register_function(menu="Surfaces > Geodesic distance from vertex (vedo, n-STRESS)")
+@register_function(menu="Surfaces > Geodesic path (pygeodesics, n-STRESS)")
 @frame_by_frame
 def geodesic_path(surface: SurfaceData,
                   index_1: int,
-                  index_2) -> VectorsData:
+                  index_2: int) -> VectorsData:
     """
-    Calculate the geodesic path from a vertex to all other vertices.
+    Calculate the geodesic path between two index-defined surface vertices .
 
     Parameters
     ----------
     surface : SurfaceData
     index_1 : int
-        Index of vertex to calculate geodesic path from.
+        Index of start vertex
     index_2 : int
-        Index of vertex to calculate geodesic path to.
+        Index of destination vertex
 
     Returns
     -------
     VectorsData
 
     """
-    import vedo
-    import numpy as np
+    from pygeodesic import geodesic
 
-    mesh = vedo.Mesh((surface[0], surface[1]))
-    path = mesh.geodesic(index_1, index_2)
+    geoalg = geodesic.PyGeodesicAlgorithmExact(surface[0], surface[1])
+    distances, path = geoalg.geodesicDistance(index_1, index_2)
 
-    # convert path points to napari vector
-    points = np.copy(path.points())
-    vectors = np.diff(points, axis=0)
+    # convert points to vectors from point to point
+    vectors = []
+    for i in range(len(path) - 1):
+        vectors.append(path[i + 1] - path[i])
+    vectors = np.asarray(vectors)
+    napari_vectors = np.stack([path[:-1], vectors]).transpose((1, 0, 2))
 
-    napari_vectors = np.stack([points[:-1], vectors]).transpose((1, 0, 2))
     return napari_vectors
 
 

--- a/src/napari_stress/_plotting/features_histogram.py
+++ b/src/napari_stress/_plotting/features_histogram.py
@@ -31,9 +31,6 @@ class FeaturesHistogramWidget(HistogramWidget):
 
     def __init__(self, napari_viewer: napari.viewer.Viewer):
         super().__init__(napari_viewer)
-
-        self.x_axis_key = None
-
         self._key_selection_widget = magicgui(
             self._set_axis_keys,
             x_axis_key={"choices": self._get_valid_axis_keys},

--- a/src/napari_stress/_tests/test_measurements.py
+++ b/src/napari_stress/_tests/test_measurements.py
@@ -17,7 +17,7 @@ def test_mean_curvature_on_ellipsoid():
             resampling_length=3.5, interpolation_method='linear',
             trace_length=10, sampling_distance=1)
 
-        # calculate each point's distance to the surface of the ellipsoid8        
+        # calculate each point's distance to the surface of the ellipsoid
         distances = []
         ellipse_points = []
         for pt in results_reconstruction[3][0]:
@@ -251,13 +251,11 @@ def test_geodesics():
     assert sum(maxima_points == 1) == 2
     assert sum(maxima_points == -1) == 2
 
-    sphere = vedo.Sphere(pos=(0, 0, 0), r=1, res=50)
-    sphere = (sphere.points(), np.asarray(sphere.faces()))
-    GDM = measurements.geodesic_distance_matrix(sphere)
+    geodesic_vectors = measurements.geodesic_path(surface, 0, 1)
 
-    assert np.isclose(GDM.max(), np.pi, rtol=0.01)
-
-    path = measurements.geodesic_path(sphere, 0, 1)
+    assert geodesic_vectors.shape[0] == 44
+    assert geodesic_vectors.shape[1] == 2
+    assert geodesic_vectors.shape[2] == 3
 
 
 def test_comprehenive_stress_toolbox(make_napari_viewer):


### PR DESCRIPTION
Reverts campaslab/napari-stress#308

This is necessary since pygeodesic uses the exact geodesic algorithm by [Mitchell et al.](https://epubs.siam.org/doi/abs/10.1137/0216045?casa_token=VGn1AyBwgpMAAAAA:ZRh0f7XSN601ZxLFpIpiEhED4ZDRNalll1Pz0KmHYA9z-1xTjrf-SBzB9k6nMb5XLMk48NbMIbM), which allows geodesic paths to cut across faces in a triangular mesh, unlike the paths that a typical Djikstra search can discover.