### PR TITLE
Scale resampling length

### DIFF
--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -293,7 +293,7 @@ def reconstruct_droplet(
     # repeat tracing `n_tracing_iterations` times
     for i in range(n_tracing_iterations):
         resampled_points = resample_pointcloud(
-            points, sampling_length=resampling_length
+            points, sampling_length=resampling_length/(target_voxelsize**2)
         )
 
         traced_points, trace_vectors = reconstruction.trace_refinement_of_surface(

--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -261,7 +261,7 @@ def reconstruct_droplet(
             - droplet center: center of droplet
 
     """
-    import copy
+    import vedo
     import napari_process_points_and_surfaces as nppas
     import napari_segment_blobs_and_things_with_membranes as nsbatwm
     from napari_stress import reconstruction
@@ -280,15 +280,12 @@ def reconstruct_droplet(
     # convert to surface
     label_image = nsbatwm.connected_component_labeling(binarized_image)
     surface = nppas.largest_label_to_surface(label_image)
-    surface = nppas.remove_duplicate_vertices(surface)
-
-    # Smooth and decimate
-    surface = nppas.smooth_surface(
-        surface, n_smoothing_iterations, feature_angle=120, edge_angle=90
-    )
-    surface = nppas.decimate_quadric(surface, number_of_vertices=n_points)
-    points_first_guess = surface[0]
-    points = copy.deepcopy(points_first_guess)
+    vedo_mesh = vedo.Mesh(surface).clean().smooth(
+                              niter=n_smoothing_iterations,
+                              feature_angle=120,
+                              edge_angle=90)
+    vedo_mesh.decimate(method='quadric', n=n_points)
+    points = vedo_mesh.vertices
 
     # repeat tracing `n_tracing_iterations` times
     for i in range(n_tracing_iterations):


### PR DESCRIPTION
## Description

This scales the `resampling_length` parameter so that the trace points numbers don't escalate for high-res data.

Fixes #349 

## Type of Change

- [x] Parameter estimation change

## How Has This Been Tested?

No tests necessary - doesn't change functionality, just the way parameters are estimated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

