### PR TITLE
constrain scipy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     pyocclient
     pyshtools<=4.10.0
     scikit-image
-    scipy
+    scipy>=1.9.0
     seaborn
     tqdm
     vedo>=2023.5.0


### PR DESCRIPTION
## Description

Constrained the sccipy version to `>=1.9.0` to make sure cubic interpolation of the `RegularGridInterpolator` is available. [First version it's included is `1.9`](https://docs.scipy.org/doc/scipy-1.9.0/reference/generated/scipy.interpolate.RegularGridInterpolator.html)

#366 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)