### PR TITLE
added `translate` parameter to processed samples

### DIFF
--- a/src/napari_stress/_measurements/toolbox.py
+++ b/src/napari_stress/_measurements/toolbox.py
@@ -177,6 +177,7 @@ class stress_analysis_toolbox(QWidget):
 
         for layer in results:
             _layer = Layer.create(data=layer[0], meta=layer[1], layer_type=layer[2])
+            _layer.translate = self.layer_select.value.translate
             self.viewer.add_layer(_layer)
 
         # Export results

--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -193,6 +193,7 @@ class droplet_reconstruction_toolbox(QWidget):
 
         for layer in results:
             _layer = Layer.create(data=layer[0], meta=layer[1], layer_type=layer[2])
+            _layer.translate=self.image_layer_select.value.translate
             self.viewer.add_layer(_layer)
 
 

--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -193,7 +193,7 @@ class droplet_reconstruction_toolbox(QWidget):
 
         for layer in results:
             _layer = Layer.create(data=layer[0], meta=layer[1], layer_type=layer[2])
-            _layer.translate=self.image_layer_select.value.translate
+            _layer.translate = self.image_layer_select.value.translate
             self.viewer.add_layer(_layer)
 
 


### PR DESCRIPTION
Used correct attribute to set translate

## Description

This sets the `translate` parameter for the layers returned by the droplet reconstruction toolbox and the comprehensive measurements toolbox. This makes sure that the resulting image overlays well with the input image.

Fixes #378

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Interactive
- [x] Unit test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
