### PR TITLE
Clarify documentation

### DIFF
--- a/docs/02_interactive_usage/01_toolboxes/demo_droplet_reconstruction_toolbox.md
+++ b/docs/02_interactive_usage/01_toolboxes/demo_droplet_reconstruction_toolbox.md
@@ -28,7 +28,7 @@ The refinement of the first selection of points consists of two principal steps 
 
 In each iteration, the following steps are done:
 * Resampling: The cartesian coordinates of the points are interpolated according to latitude and longitude. The resampled points are drawn according to a fibonacci-scheme. You can control the number of points that are sampled with the following parameters:
-    * `Point resampling length` field: The larger this value is, the more scarce the points will be on the surface.
+    * `Point resampling length` field: The larger this value is, the more scarce the points will be on the surface. Note that the `Point resampling length` is given in pixels. The size of objects in pixels may change although the phyiscal size of the object is the same. Hence, the results for the same objects may be different for the same parameters if the image is sampled to different voxel sizes.
     * `Number of iterations`: The larger this value is, the more times the entire procedure in this step is repeated. The more iterations you perform, the longer the processing will take.
 * Trace-refinement: Normals are cast outwards from the sample point and the intesity in the rescaled image along the vectors is mmeasured. The surface point is then moved along this line to best fit the intensity distribution. For more details, see [this notebook](glossary:surface_tracing:code). In short, the parameters control:
     * `Fluorescence type`: Whether the droplet is labelled on the surface or in the interior.

--- a/docs/04_FAQ/settings_reconstruction_bulk.yaml
+++ b/docs/04_FAQ/settings_reconstruction_bulk.yaml
@@ -6,7 +6,7 @@ n_smoothing_iterations: 15
 n_tracing_iterations: 1
 outlier_tolerance: 1.5
 remove_outliers: true
-resampling_length: 5.0
+resampling_length: 5.0 # resampling_length is given in pixels
 sampling_distance: 1.0
 smoothing_sigma: 1.0
 target_voxelsize: 0.2868

--- a/docs/04_FAQ/settings_reconstruction_surface.yaml
+++ b/docs/04_FAQ/settings_reconstruction_surface.yaml
@@ -6,7 +6,7 @@ n_smoothing_iterations: 15
 n_tracing_iterations: 1
 outlier_tolerance: 1.5
 remove_outliers: true
-resampling_length: 5.0
+resampling_length: 5.0 # resampling_length is given in pixels
 sampling_distance: 1.0
 smoothing_sigma: 1.0
 target_voxelsize: 0.2868

--- a/src/napari_stress/_reconstruction/toolbox.py
+++ b/src/napari_stress/_reconstruction/toolbox.py
@@ -206,7 +206,7 @@ def reconstruct_droplet(
     n_smoothing_iterations: int = 10,
     n_points: int = 256,
     n_tracing_iterations: int = 1,
-    resampling_length: float = 5,
+    resampling_length: float = 5,  # resampling_length is given in pixels
     fit_type: str = "fancy",
     edge_type: str = "interior",
     trace_length: float = 10,
@@ -235,9 +235,10 @@ def reconstruct_droplet(
         Number of points to be sampled. The default is 256.
     n_tracing_iterations : int, optional
         Number of tracing iterations. The default is 1.
-    resampling_length : float, optional
+    resampling_length: float, optional
         Distance between sampled point locations. The default is 5.
         Choose smaller values for more accurate reconstruction.
+        Note that the resampling_length is given in pixels.
     fit_type : str, optional
         Type of fit to be used. The default is "fancy". Can also be "quick".
     edge_type : str, optional


### PR DESCRIPTION
Fixes #377

Clarify documentation regarding point resampling length in pixels.

* **Documentation Updates:**
  - Add a note in `docs/02_interactive_usage/01_toolboxes/demo_droplet_reconstruction_toolbox.md` specifying that the `Point resampling length` field is given in pixels and that the size of objects in pixels may change although the physical size of the object is the same.
  - Add comments in `docs/04_FAQ/settings_reconstruction_bulk.yaml` and `docs/04_FAQ/settings_reconstruction_surface.yaml` specifying that the `resampling_length` parameter is given in pixels.

* **Code Updates:**
  - Add a comment in `src/napari_stress/_reconstruction/toolbox.py` in the `reconstruct_droplet` function specifying that the `resampling_length` parameter is given in pixels.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/campaslab/napari-stress/issues/377?shareId=40d37f28-399e-49b2-a49f-bcd52af8d2c7).