### PR TITLE
Fix metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "scipy>=1.9.0",
     "seaborn",
     "tqdm",
+    "napari-vedo-bridge>=0.2.1",
     "vedo>=2023.5.0",
     "vispy",
     "deprecation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "napari_stress"
+name = "napari-stress"
 dynamic = ["version"]
 description = "Interactive surface analysis in napari for measuring mechanical stresses in biological tissues"
 readme = "README.md"


### PR DESCRIPTION
This pull request includes changes to the `pyproject.toml` file to update the project name and add a new dependency. 

Project configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2): Changed the project name from "napari_stress" to "napari-stress".

Dependencies updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R41): Added `napari-vedo-bridge>=0.2.1` to the list of dependencies.