### PR TITLE
unpin numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "mpmath",
     "napari",
     "napari-tools-menu>=0.1.15",
-    "numpy<1.24.0",
+    "numpy",
     "pandas",
     "pygeodesic",
     "scikit-image",


### PR DESCRIPTION
## Description

Released numpy version pin

Fixes #303 

## Long description

This pull request updates a dependency in the `pyproject.toml` file to remove a version constraint on `numpy`.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R34): Updated the `numpy` dependency by removing the `<1.24.0` version constraint, allowing for broader compatibility with newer versions of `numpy`.
