### PR TITLE
fix python access to napari function

### DIFF
--- a/src/napari_stress/_measurements/curvature.py
+++ b/src/napari_stress/_measurements/curvature.py
@@ -254,6 +254,7 @@ def calculate_patch_fitted_curvature_on_pointcloud(
     df = pd.DataFrame(
         {
             "mean_curvature": mean_curvatures,
+            "gaussian_curvature": principal_curvatures[:, 0] * principal_curvatures[:, 1],
             "principal_curvature_1": principal_curvatures[:, 0],
             "principal_curvature_2": principal_curvatures[:, 1],
         }

--- a/src/napari_stress/napari.yaml
+++ b/src/napari_stress/napari.yaml
@@ -60,7 +60,7 @@ contributions:
       python_name: napari_stress.approximation:curvature_on_ellipsoid
       title: Measure curvature on ellipsoid
     - id: napari-stress.calculate_patch_fitted_curvature_surface
-      python_name: napari_stress.measurements:calculate_patch_fitted_curvature_on_surface
+      python_name: napari_stress._measurements.curvature:_calculate_patch_fitted_curvature_on_surface
       title: Calculate patch-fitted curvature on surface
 
     # stress measurements


### PR DESCRIPTION
This pull request introduces an enhancement to curvature measurements by adding Gaussian curvature to the output and updates the YAML configuration to reflect a corrected module path for a curvature calculation function.

### Enhancements to curvature measurements:
* [`src/napari_stress/_measurements/curvature.py`](diffhunk://#diff-45646e3ae7477aeaff95de3aa47f915ef244cd39b3a28bad6fafc60823119ec7R257): Added a new column, `"gaussian_curvature"`, to the DataFrame in the `calculate_patch_fitted_curvature_on_pointcloud` function. The Gaussian curvature is computed as the product of the two principal curvatures.

### YAML configuration updates:
* [`src/napari_stress/napari.yaml`](diffhunk://#diff-86eb3bc9675670611a8734585de9fc43521a992909a982a8469a30b9233a7c83L63-R63): Updated the `python_name` for the `calculate_patch_fitted_curvature_on_surface` function to reflect its correct module path (`napari_stress._measurements.curvature`).