### PR TITLE
add mesh cleaning to mesh sanitizing

### DIFF
--- a/src/napari_stress/_utils/_utils.py
+++ b/src/napari_stress/_utils/_utils.py
@@ -26,6 +26,10 @@ def sanitize_faces(
     'napari.types.SurfaceData'
         The sanitized surface data.
     """
+    import vedo
+
+    mesh = vedo.Mesh((surface[0], surface[1])).clean()
+    surface = (mesh.vertices, np.asarray(mesh.cells))
     # Ensure faces are in the correct format
     faces = surface[1]
     vertices = surface[0]


### PR DESCRIPTION
This pull request introduces a change to the `sanitize_faces` function in `src/napari_stress/_utils/_utils.py`, adding functionality to clean the surface data using the `vedo` library.

Enhancements to surface data sanitization:

* [`src/napari_stress/_utils/_utils.py`](diffhunk://#diff-0c1937c0412b85f0a5de90d338d361308b66d2b828da2aa8fbce4ff1232f5b7bR29-R32): Introduced the `vedo` library to clean surface data by creating a `vedo.Mesh` object and updating the `surface` tuple with cleaned vertices and cells.