### PR TITLE
remove time column from sample data

### DIFF
--- a/src/napari_stress/_sample_data/sample_data.py
+++ b/src/napari_stress/_sample_data/sample_data.py
@@ -13,7 +13,7 @@ def get_droplet_point_cloud() -> LayerDataTuple:
     df = pd.read_csv(
         os.path.join(DATA_ROOT, "dropplet_point_cloud.csv"), sep=","
     )
-    coordinates = df[["axis-0", "axis-1", "axis-2", "axis-3"]].to_numpy()
+    coordinates = df[["axis-1", "axis-2", "axis-3"]].to_numpy()
 
     return [(coordinates, {"size": 0.5, "face_color": "orange"}, "points")]
 


### PR DESCRIPTION
This pull request includes a change to the `get_droplet_point_cloud` function in `src/napari_stress/_sample_data/sample_data.py`. The modification removes the inclusion of the "axis-0" column when converting the DataFrame to a NumPy array, ensuring that only "axis-1", "axis-2", and "axis-3" (aka zyx) are used for the `coordinates`.