### PR TITLE
Fix short trace bug

### DIFF
--- a/src/napari_stress/_reconstruction/fit_utils.py
+++ b/src/napari_stress/_reconstruction/fit_utils.py
@@ -252,8 +252,7 @@ def estimate_fit_parameters(intensity):
     """
     # Check if there are too few points
     if len(intensity) < 5:
-        print("Warning: Too few points in trace (length < 5)")
-        return [np.nan] * 5, intensity, intensity
+        raise ValueError("Warning: Too few points in trace (length < 5)")
 
     # Calculate the first derivative (dY)
     dY = 0.5 * (

--- a/src/napari_stress/_reconstruction/fit_utils.py
+++ b/src/napari_stress/_reconstruction/fit_utils.py
@@ -183,7 +183,7 @@ def _fancy_edge_fit(
         DESCRIPTION.
     """
     params = _function_args_to_list(selected_edge_func)[1:]
-    array = [x for x in array if not np.isnan(x)]  # filter out nans
+    array = array[~np.isnan(array)]  # filter out nans
     try:
         if selected_edge_func == _sigmoid:
             # estimate parameters and trim intensity array


### PR DESCRIPTION
## Description

Running napari-stress in batch on many images often triggered a warning:
`Warning: Too few points in trace (length < 5)`
And then the surface reconstruction would stop with an index out of bounds exception.
This fix solves the problem. I could compute the surface reconstruction for many
more images.

There is also clearly a bug in the code since the two return statements in estimate_fit_parameters don't match.
This PR solves the problem by replacing the "exceptional" return statement with a "raise ValueError" which is properly
handled in _fancy_edge_fit. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Worked in my pipeline. But the proper solution would be to increase unit test coverage for this situation trace lenght < 5.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

