### PR TITLE
fix: do not use deprecated scipy functions anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numpy<2.0.0",
     "pandas",
     "scikit-image",
-    "scipy>=1.9.0",
+    "scipy>=1.15.0",
     "seaborn",
     "tqdm",
     "napari-vedo-bridge>=0.2.2",

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -25,4 +25,3 @@ python:
    - requirements: docs/requirements.txt
    - method: pip
      path: .
-

--- a/src/napari_stress/_approximation/expansion_spherical_harmonics.py
+++ b/src/napari_stress/_approximation/expansion_spherical_harmonics.py
@@ -315,7 +315,7 @@ class SphericalHarmonicsExpander(Expander):
         """
         Perform least squares harmonic fit on input points using vectorized spherical harmonics.
         """
-        from scipy.special import sph_harm
+        from scipy.special import sph_harm_y
 
         U, V = sample_locations
 
@@ -325,10 +325,10 @@ class SphericalHarmonicsExpander(Expander):
             for m in range(-1 * n, n + 1):
                 Y_mn_coors_in = []
                 if m >= 0:
-                    Y_mn_coors_in = sph_harm(m, n, U, V).real
+                    Y_mn_coors_in = sph_harm_y(m, n, U, V).real
 
                 else:  # m<0, we use Y^(-m)_n.imag
-                    Y_mn_coors_in = sph_harm(-1 * m, n, U, V).imag
+                    Y_mn_coors_in = sph_harm_y(-1 * m, n, U, V).imag
                 All_Y_mn_pt_in.append(Y_mn_coors_in)
 
         coefficients = np.linalg.lstsq(np.stack(All_Y_mn_pt_in).T, values)[0]

--- a/src/napari_stress/_stress/lebedev_info_SPB.py
+++ b/src/napari_stress/_stress/lebedev_info_SPB.py
@@ -177,7 +177,8 @@ def Der_Phi_Basis_Fn(
                 return (
                     np.sqrt((N_Coef) * (N_Coef + 1))
                     * (
-                        (np.exp(-1j * Theta)) * sph_harm_y(1, N_Coef, Theta, Phi)
+                        (np.exp(-1j * Theta))
+                        * sph_harm_y(1, N_Coef, Theta, Phi)
                     ).real
                 )
             else:

--- a/src/napari_stress/_stress/lebedev_info_SPB.py
+++ b/src/napari_stress/_stress/lebedev_info_SPB.py
@@ -9,7 +9,7 @@ import pickle as pkl
 
 import mpmath
 import numpy as np
-from scipy.special import sph_harm
+from scipy.special import sph_harm_y
 
 from .charts_SPB import Cart_To_Coor_A, Domain, eta_A
 from .lebedev_write_SPB import Lebedev  # lists all Lebdv quadratures
@@ -109,10 +109,10 @@ def get_quad_degree(quad_pts):
 
 def Eval_SPH_Basis(M_Coef, N_Coef, Theta, Phi):
     if M_Coef >= 0:
-        return sph_harm(M_Coef, N_Coef, Theta, Phi).real
+        return sph_harm_y(M_Coef, N_Coef, Theta, Phi).real
 
     else:  # m<0, we use Y^(-m)_n.imag
-        return sph_harm(-1 * M_Coef, N_Coef, Theta, Phi).imag
+        return sph_harm_y(-1 * M_Coef, N_Coef, Theta, Phi).imag
 
 
 # Evaluates d_phi(Y^m_n) at SINGLE PT
@@ -132,7 +132,7 @@ def Der_Phi_Basis_Fn(
                     np.sqrt((N_Coef) * (N_Coef + 1))
                     * (
                         (np.e ** (-1j * Theta))
-                        * sph_harm(1, N_Coef, Theta, Phi)
+                        * sph_harm_y(1, N_Coef, Theta, Phi)
                     ).real
                 )
             else:
@@ -140,7 +140,7 @@ def Der_Phi_Basis_Fn(
 
         elif M_Coef < 0:
             m_sph = -1 * M_Coef
-            Der_Phi_Val += (m_sph * mpmath.cot(Phi)) * sph_harm(
+            Der_Phi_Val += (m_sph * mpmath.cot(Phi)) * sph_harm_y(
                 m_sph, N_Coef, Theta, Phi
             ).imag
 
@@ -149,13 +149,13 @@ def Der_Phi_Basis_Fn(
                     np.sqrt((N_Coef - m_sph) * (N_Coef + m_sph + 1))
                     * (
                         (np.e ** (-1j * Theta))
-                        * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                        * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                     ).imag
                 )
 
         else:  # M_Coef >= 0
             m_sph = M_Coef
-            Der_Phi_Val += (m_sph * mpmath.cot(Phi)) * sph_harm(
+            Der_Phi_Val += (m_sph * mpmath.cot(Phi)) * sph_harm_y(
                 m_sph, N_Coef, Theta, Phi
             ).real
 
@@ -164,7 +164,7 @@ def Der_Phi_Basis_Fn(
                     np.sqrt((N_Coef - m_sph) * (N_Coef + m_sph + 1))
                     * (
                         (np.e ** (-1j * Theta))
-                        * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                        * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                     ).real
                 )
 
@@ -177,7 +177,7 @@ def Der_Phi_Basis_Fn(
                 return (
                     np.sqrt((N_Coef) * (N_Coef + 1))
                     * (
-                        (np.exp(-1j * Theta)) * sph_harm(1, N_Coef, Theta, Phi)
+                        (np.exp(-1j * Theta)) * sph_harm_y(1, N_Coef, Theta, Phi)
                     ).real
                 )
             else:
@@ -185,7 +185,7 @@ def Der_Phi_Basis_Fn(
 
         elif M_Coef < 0:
             m_sph = -1 * M_Coef
-            Der_Phi_Val += (m_sph * (1.0 / np.tan(Phi))) * sph_harm(
+            Der_Phi_Val += (m_sph * (1.0 / np.tan(Phi))) * sph_harm_y(
                 m_sph, N_Coef, Theta, Phi
             ).imag
 
@@ -194,13 +194,13 @@ def Der_Phi_Basis_Fn(
                     np.sqrt((N_Coef - m_sph) * (N_Coef + m_sph + 1))
                     * (
                         (np.exp(-1j * Theta))
-                        * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                        * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                     ).imag
                 )
 
         else:  # M_Coef >= 0
             m_sph = M_Coef
-            Der_Phi_Val += (m_sph * (1.0 / np.tan(Phi))) * sph_harm(
+            Der_Phi_Val += (m_sph * (1.0 / np.tan(Phi))) * sph_harm_y(
                 m_sph, N_Coef, Theta, Phi
             ).real
 
@@ -209,7 +209,7 @@ def Der_Phi_Basis_Fn(
                     np.sqrt((N_Coef - m_sph) * (N_Coef + m_sph + 1))
                     * (
                         (np.exp(-1j * Theta))
-                        * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                        * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                     ).real
                 )
 
@@ -227,7 +227,7 @@ def Der_Phi_Phi_Basis_Fn(
         Der_Phi_Phi_Val += (
             m_sph
             * (m_sph * (mpmath.cot(Phi) ** 2) - (mpmath.csc(Phi) ** 2))
-            * sph_harm(m_sph, N_Coef, Theta, Phi).imag
+            * sph_harm_y(m_sph, N_Coef, Theta, Phi).imag
         )
 
         if m_sph < N_Coef:
@@ -237,7 +237,7 @@ def Der_Phi_Phi_Basis_Fn(
                 * mpmath.cot(Phi)
                 * (
                     (np.e ** (-1j * Theta))
-                    * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                    * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                 ).imag
             )
 
@@ -251,7 +251,7 @@ def Der_Phi_Phi_Basis_Fn(
                 )
                 * (
                     (np.e ** (-2j * Theta))
-                    * sph_harm(m_sph + 2, N_Coef, Theta, Phi)
+                    * sph_harm_y(m_sph + 2, N_Coef, Theta, Phi)
                 ).imag
             )
 
@@ -260,7 +260,7 @@ def Der_Phi_Phi_Basis_Fn(
         Der_Phi_Phi_Val += (
             m_sph
             * (m_sph * (mpmath.cot(Phi) ** 2) - (mpmath.csc(Phi) ** 2))
-            * sph_harm(m_sph, N_Coef, Theta, Phi).real
+            * sph_harm_y(m_sph, N_Coef, Theta, Phi).real
         )
 
         if m_sph < N_Coef:
@@ -270,7 +270,7 @@ def Der_Phi_Phi_Basis_Fn(
                 * mpmath.cot(Phi)
                 * (
                     (np.e ** (-1j * Theta))
-                    * sph_harm(m_sph + 1, N_Coef, Theta, Phi)
+                    * sph_harm_y(m_sph + 1, N_Coef, Theta, Phi)
                 ).real
             )
         if m_sph < (N_Coef - 1):
@@ -283,7 +283,7 @@ def Der_Phi_Phi_Basis_Fn(
                 )
                 * (
                     (np.e ** (-2j * Theta))
-                    * sph_harm(m_sph + 2, N_Coef, Theta, Phi)
+                    * sph_harm_y(m_sph + 2, N_Coef, Theta, Phi)
                 ).real
             )
 


### PR DESCRIPTION
This pull request updates the codebase to consistently use a custom or alternative implementation of spherical harmonics, `sph_harm_y`, instead of the standard `scipy.special.sph_harm`. Additionally, it raises the minimum required version of `scipy` in the dependencies. These changes are primarily aimed at improving numerical consistency or addressing compatibility issues with the spherical harmonics functions.

**Dependency update:**
* Increased the minimum version requirement for `scipy` from `1.9.0` to `1.15.0` in `pyproject.toml`.

**Refactor to use `sph_harm_y` instead of `sph_harm`:**
* Replaced all imports of `sph_harm` with `sph_harm_y` in `src/napari_stress/_approximation/expansion_spherical_harmonics.py` and `src/napari_stress/_stress/lebedev_info_SPB.py`. [[1]](diffhunk://#diff-991763f65696800280c704709715b65837e7be31600fafd3835a89f0d43c83edL318-R318) [[2]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL12-R12)
* Updated all function calls from `sph_harm` to `sph_harm_y` throughout spherical harmonics-related computations, including least squares fitting and basis function evaluations in both `expansion_spherical_harmonics.py` and `lebedev_info_SPB.py`. [[1]](diffhunk://#diff-991763f65696800280c704709715b65837e7be31600fafd3835a89f0d43c83edL328-R331) [[2]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL112-R115) [[3]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL135-R143) [[4]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL152-R158) [[5]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL167-R167) [[6]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL180-R188) [[7]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL197-R203) [[8]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL212-R212) [[9]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL230-R230) [[10]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL240-R240) [[11]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL254-R254) [[12]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL263-R263) [[13]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL273-R273) [[14]](diffhunk://#diff-bc745b39547226a1ad5c5a7f866b2026542489036f2873fab90e400f9b5df0daL286-R286)